### PR TITLE
Enable WebView contents debugging in debug builds (closes #254)

### DIFF
--- a/common/src/main/java/jp/co/soramitsu/common/presentation/compose/webview/WebView.kt
+++ b/common/src/main/java/jp/co/soramitsu/common/presentation/compose/webview/WebView.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import jp.co.soramitsu.common.BuildConfig
 import jp.co.soramitsu.common.base.ProgressDialog
 import jp.co.soramitsu.ui_core.theme.customColors
 
@@ -50,6 +51,11 @@ fun WebView(
     state: WebViewState,
     onPageFinished: () -> Unit
 ) {
+    if (BuildConfig.DEBUG) {
+        // Allow Appium and chrome://inspect to discover the WebView contents in
+        // debug builds only. Release builds remain non-inspectable.
+        WebView.setWebContentsDebuggingEnabled(true)
+    }
     Box(
         modifier = Modifier
             .background(color = MaterialTheme.customColors.bgPage)


### PR DESCRIPTION
## Enable WebView contents debugging in debug builds

Closes #254

### What changed

`common/src/main/java/jp/co/soramitsu/common/presentation/compose/webview/WebView.kt`

Calls `WebView.setWebContentsDebuggingEnabled(true)` once when the composable runs, but only when `BuildConfig.DEBUG` is true. This is exactly what the Android remote-debugging guide recommends and it is what Appium needs in order to surface the WebView locators that the issue describes.

The call is gated to debug builds. Release builds stay non-inspectable, which keeps key material and signed-transaction state out of reach of anyone with USB access on a production device.

### Key snippet

```kotlin
import jp.co.soramitsu.common.BuildConfig

@Composable
fun WebView(
    state: WebViewState,
    onPageFinished: () -> Unit
) {
    if (BuildConfig.DEBUG) {
        WebView.setWebContentsDebuggingEnabled(true)
    }
    // existing Box + AndroidView block follows
}
```
